### PR TITLE
Tauri: publish app version as sw_version in MQTT discovery

### DIFF
--- a/tauri/src-tauri/src/mqtt_service.rs
+++ b/tauri/src-tauri/src/mqtt_service.rs
@@ -174,7 +174,10 @@ async fn publish_discovery_inner(client: &AsyncClient, prefix: &str) {
         "identifiers": [format!("teams2ha_{prefix}")],
         "name": format!("Teams2HA ({})", prefix),
         "model": "Teams2HA",
-        "manufacturer": "jimmyeao"
+        "manufacturer": "jimmyeao",
+        // Real app version (release builds get it stamped from the git tag). Without this
+        // the device registry keeps showing whatever an older install once published.
+        "sw_version": env!("CARGO_PKG_VERSION")
     });
 
     let switches = [("ismuted", "Is Muted"), ("isvideoon", "Is Video On")];


### PR DESCRIPTION
The MQTT discovery device block carries no `sw_version`, so Home Assistant's device page keeps showing whatever an older install once published (in my case a stale "1.0" from the legacy .NET version, which used the same device identifier).

This adds `sw_version` using `CARGO_PKG_VERSION`, so HA shows the real application version and it updates automatically with each release.

Small and self-contained on purpose — unrelated to #93, works standalone. Same disclosure as over there: developed with AI assistance, tested against my own broker/HA setup (device page now shows the actual version after the app reconnects).

🤖 Generated with [Claude Code](https://claude.com/claude-code)