### PR TITLE
Fix TLS transport selection: never silently downgrade to plaintext

### DIFF
--- a/tauri/src-tauri/src/mqtt_service.rs
+++ b/tauri/src-tauri/src/mqtt_service.rs
@@ -79,8 +79,21 @@ impl MqttService {
             opts.set_credentials(&settings.mqtt_username, &settings.mqtt_password);
         }
 
-        if settings.use_tls && !settings.ignore_cert_errors {
-            opts.set_transport(Transport::Tls(TlsConfiguration::Native));
+        // "Use TLS" must always yield an encrypted transport. Previously the
+        // ignore_cert_errors flag silently downgraded TLS to plain TCP, and the
+        // TLS+websockets combination came out as unencrypted ws://.
+        if settings.use_tls {
+            if settings.ignore_cert_errors {
+                log::warn!(
+                    "MQTT: 'ignore certificate errors' is not supported; \
+                     connecting with TLS and full certificate verification"
+                );
+            }
+            if settings.use_websockets {
+                opts.set_transport(Transport::Wss(TlsConfiguration::Native));
+            } else {
+                opts.set_transport(Transport::Tls(TlsConfiguration::Native));
+            }
         } else if settings.use_websockets {
             opts.set_transport(Transport::Ws);
         }


### PR DESCRIPTION
Two issues in the transport selection in `mqtt_service.rs`:

1. **"Use TLS" + "ignore certificate errors" connected over plain TCP.** The condition `use_tls && !ignore_cert_errors` meant that enabling the cert-skip toggle silently dropped encryption entirely — the opposite of what a user enabling TLS expects.
2. **TLS + websockets produced `ws://` instead of `wss://`.**

With this change `use_tls` always yields an encrypted transport (`Tls` or `Wss`). Skipping certificate verification isn't supported by the current rumqttc setup, so that flag now logs a warning instead of downgrading the connection.

Found during a code review of our fork (same one PR #93 came from); written with AI assistance and reviewed by me.

🤖 Generated with [Claude Code](https://claude.com/claude-code)