### PR TITLE
Publish state to MQTT only when it actually changed

### DIFF
--- a/tauri/src-tauri/src/app_state.rs
+++ b/tauri/src-tauri/src/app_state.rs
@@ -6,6 +6,10 @@ use tokio::sync::RwLock;
 pub struct AppState {
     pub meeting: MeetingState,
     pub log_watcher_in_call: bool,
+    /// Last state that was actually delivered to MQTT — used to skip republishing
+    /// an unchanged state on every monitor event. Only set after a successful
+    /// publish, so a failed publish is retried on the next event.
+    pub last_published: Option<MeetingState>,
 }
 
 pub type SharedState = Arc<RwLock<AppState>>;

--- a/tauri/src-tauri/src/lib.rs
+++ b/tauri/src-tauri/src/lib.rs
@@ -333,10 +333,13 @@ async fn handle_home_change(
 /// fire far more often than the state actually changes. The ConnAck path passes
 /// `force` true so a fresh connection always gets a full state push.
 async fn publish(mqtt: &MqttHandle, app: &AppHandle, shared: &SharedState, force: bool) {
-    let state = shared.read().await.meeting.clone();
-    if !force && shared.read().await.last_published.as_ref() == Some(&state) {
-        return;
-    }
+    let state = {
+        let s = shared.read().await;
+        if !force && s.last_published.as_ref() == Some(&s.meeting) {
+            return;
+        }
+        s.meeting.clone()
+    };
     let mut delivered = false;
     if let Some(svc) = mqtt.read().await.as_ref() {
         match svc.publish_state(&state).await {

--- a/tauri/src-tauri/src/lib.rs
+++ b/tauri/src-tauri/src/lib.rs
@@ -237,7 +237,7 @@ pub fn run() {
                         Some(()) = reconnect_rx.recv() => {
                             // ConnAck received — push current state so HA sensors
                             // get real values immediately rather than waiting for a change.
-                            publish(&mqtt_h3, &handle3, &shared2).await;
+                            publish(&mqtt_h3, &handle3, &shared2, true).await;
                         }
                         Some(ev) = home_rx.recv() => {
                             handle_home_event(ev, &mqtt_h3, &handle3, &cmd_tx3, &reconnect_tx3).await;
@@ -328,12 +328,26 @@ async fn handle_home_change(
     }
 }
 
-async fn publish(mqtt: &MqttHandle, app: &AppHandle, shared: &SharedState) {
+/// Publish the current state to MQTT and the UI. With `force` false the publish is
+/// skipped when nothing changed since the last successful publish — monitor events
+/// fire far more often than the state actually changes. The ConnAck path passes
+/// `force` true so a fresh connection always gets a full state push.
+async fn publish(mqtt: &MqttHandle, app: &AppHandle, shared: &SharedState, force: bool) {
     let state = shared.read().await.meeting.clone();
+    if !force && shared.read().await.last_published.as_ref() == Some(&state) {
+        return;
+    }
+    let mut delivered = false;
     if let Some(svc) = mqtt.read().await.as_ref() {
-        if let Err(e) = svc.publish_state(&state).await {
-            log::warn!("Publish state error: {e}");
+        match svc.publish_state(&state).await {
+            Ok(()) => delivered = true,
+            Err(e) => log::warn!("Publish state error: {e}"),
         }
+    }
+    if delivered {
+        // Only cache after success: a failed/skipped delivery (e.g. MQTT paused)
+        // must be retried on the next event or the ConnAck re-publish.
+        shared.write().await.last_published = Some(state.clone());
     }
     app.emit("state-update", &state).ok();
 }
@@ -357,7 +371,7 @@ async fn handle_log_event(ev: LogEvent, shared: &SharedState, mqtt: &MqttHandle,
         LogEvent::UnreadMessages(u) => s.meeting.has_unread_messages = u,
     }
     drop(s);
-    publish(mqtt, app, shared).await;
+    publish(mqtt, app, shared, false).await;
 }
 
 async fn handle_wasapi_event(
@@ -372,7 +386,7 @@ async fn handle_wasapi_event(
         s.meeting.is_muted = muted;
     }
     drop(s);
-    publish(mqtt, app, shared).await;
+    publish(mqtt, app, shared, false).await;
 }
 
 async fn handle_registry_event(
@@ -398,7 +412,7 @@ async fn handle_registry_event(
         }
     }
     drop(s);
-    publish(mqtt, app, shared).await;
+    publish(mqtt, app, shared, false).await;
 }
 
 async fn handle_process_event(
@@ -411,5 +425,5 @@ async fn handle_process_event(
     let mut s = shared.write().await;
     s.meeting.teams_running = running;
     drop(s);
-    publish(mqtt, app, shared).await;
+    publish(mqtt, app, shared, false).await;
 }

--- a/tauri/src-tauri/src/mqtt_service.rs
+++ b/tauri/src-tauri/src/mqtt_service.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 use tauri::{AppHandle, Emitter};
 use tokio::sync::{mpsc, watch};
 
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct MeetingState {
     pub is_muted: bool,
@@ -163,7 +163,7 @@ impl MqttService {
         }
 
         if !state.presence.is_empty() {
-            log::info!(
+            log::debug!(
                 "MQTT publishing teamsstatus: '{}' → homeassistant/sensor/{prefix}/teamsstatus/state",
                 state.presence
             );


### PR DESCRIPTION
Every monitor event (log line, WASAPI poll, registry poll, process poll) republished **all** topics, even when nothing changed — the same presence value could be published several times within seconds, with an info-level log line each time.

The state is now cached after a successful delivery and unchanged states are skipped. A fresh connection (ConnAck) still forces a full push, and the cache is only updated on success so a failed publish is retried on the next event. The per-publish log line moved to debug level.

Found during a code review of our fork; written with AI assistance and reviewed by me.

🤖 Generated with [Claude Code](https://claude.com/claude-code)