### PR TITLE
Home detection: treat a crashed MAC lookup like a timeout

### DIFF
--- a/tauri/src-tauri/src/home_network.rs
+++ b/tauri/src-tauri/src/home_network.rs
@@ -76,7 +76,12 @@ pub fn start(tx: mpsc::Sender<HomeEvent>, mut mac_rx: watch::Receiver<String>) {
             )
             .await
             {
-                Ok(join) => join.unwrap_or(true),
+                // Treat a crashed lookup task the same as a timed-out one: "not home".
+                // The two-strike debounce below absorbs a one-off failure either way.
+                Ok(join) => join.unwrap_or_else(|e| {
+                    log::warn!("Gateway MAC lookup task failed ({e}); treating as not home");
+                    false
+                }),
                 Err(_) => {
                     log::warn!("Gateway MAC lookup timed out; treating as not home");
                     false


### PR DESCRIPTION
In the home-network poller a panicked gateway-MAC lookup task counted as **home** (`join.unwrap_or(true)`) while a timed-out lookup counted as **not home** — two comparable failure modes with opposite outcomes. Both now resolve to "not home"; the existing two-strike debounce absorbs one-off failures either way.

Follow-up to #93. Written with AI assistance and reviewed by me.

🤖 Generated with [Claude Code](https://claude.com/claude-code)