### PR TITLE
fix: detect Teams camera via UIA button, fall back to registry

### DIFF
--- a/tauri/src-tauri/src/app_state.rs
+++ b/tauri/src-tauri/src/app_state.rs
@@ -19,6 +19,17 @@ pub struct AppState {
     /// window / button not found) — deliberately distinct from `Some(false)`, so a
     /// missing reading never reads as "unmuted".
     pub uia_muted: Option<bool>,
+    /// Teams' in-app camera button, from UI Automation. Same `None` convention as
+    /// `uia_muted`. See `recompute_video` in `lib.rs`: authoritative over
+    /// `last_registry_video` whenever a reading is available.
+    pub uia_video: Option<bool>,
+    /// Windows only: the Privacy Consent Store's camera-in-use flag for Teams (see
+    /// `registry_monitor`). Reliable for a physical webcam, but a virtual-camera
+    /// passthrough (e.g. NVIDIA Broadcast) can leave it never updating, since that path
+    /// doesn't always route through the Frame Server capability check the store is fed
+    /// by. Kept only as `recompute_video`'s fallback for when there is no meeting window
+    /// yet to read a camera button from.
+    pub last_registry_video: bool,
     /// Last state that was actually delivered to MQTT — used to skip republishing
     /// an unchanged state on every monitor event. Only set after a successful
     /// publish, so a failed publish is retried on the next event.

--- a/tauri/src-tauri/src/lib.rs
+++ b/tauri/src-tauri/src/lib.rs
@@ -468,6 +468,23 @@ fn recompute_muted(s: &mut AppState) {
     };
 }
 
+/// Combine the two video sources into `meeting.is_video_on`.
+///
+/// * `uia_video` — Teams' own camera button, read from its meeting-toolbar window.
+///   Authoritative whenever available: it reflects what Teams itself believes about
+///   video state, regardless of which device is actually feeding the camera — including
+///   virtual-camera passthroughs like NVIDIA Broadcast, whose consent-store entry
+///   `last_registry_video` can miss entirely. `None` = no reading (no meeting window, or
+///   button not found).
+/// * `last_registry_video` — Windows' Privacy Consent Store camera-in-use flag for
+///   Teams. Used only when there is no UIA reading to prefer.
+///
+/// Unlike `recompute_muted`, this is not an OR: the two are competing estimates of one
+/// fact, not two independent things that can each really turn the camera on.
+fn recompute_video(s: &mut AppState) {
+    s.meeting.is_video_on = s.uia_video.unwrap_or(s.last_registry_video);
+}
+
 async fn handle_uia_event(
     ev: UiaEvent,
     shared: &SharedState,
@@ -479,14 +496,19 @@ async fn handle_uia_event(
         UiaEvent::MuteChanged(m) => s.uia_muted = Some(m),
         UiaEvent::Unknown => s.uia_muted = None,
         UiaEvent::VideoChanged(on) => {
-            s.meeting.is_video_on = on;
-            // macOS only in practice (Windows never constructs this variant, so this arm is
-            // dead code there): there is no macOS equivalent of registry_monitor's mic-in-use
-            // signal yet, so this is the only mac signal that can start a meeting. Mirrors how
-            // handle_registry_event's MicChanged(true) eagerly sets is_in_meeting on Windows.
+            s.uia_video = Some(on);
+            recompute_video(&mut s);
+            // There is no registry_monitor mic-in-use signal on macOS, so this is the only
+            // mac signal that can start a meeting. On Windows, RegistryEvent::MicChanged
+            // usually gets there first, but this is just as valid a starting signal on the
+            // rare poll where it doesn't.
             if !s.meeting.is_in_meeting {
                 s.meeting.is_in_meeting = true;
             }
+        }
+        UiaEvent::VideoUnknown => {
+            s.uia_video = None;
+            recompute_video(&mut s);
         }
     }
     if s.meeting.is_in_meeting {
@@ -524,7 +546,10 @@ async fn handle_registry_event(
 ) {
     let mut s = shared.write().await;
     match ev {
-        RegistryEvent::CameraChanged(active) => s.meeting.is_video_on = active,
+        RegistryEvent::CameraChanged(active) => {
+            s.last_registry_video = active;
+            recompute_video(&mut s);
+        }
         RegistryEvent::MicChanged(active) => {
             if active && !s.meeting.is_in_meeting {
                 s.meeting.is_in_meeting = true;
@@ -561,7 +586,7 @@ async fn handle_process_event(
 // Tests last: clippy's items_after_test_module rejects anything defined below them.
 #[cfg(test)]
 mod tests {
-    use super::recompute_muted;
+    use super::{recompute_muted, recompute_video};
     use crate::app_state::AppState;
 
     fn muted(uia: Option<bool>, wasapi: Option<bool>) -> bool {
@@ -605,5 +630,30 @@ mod tests {
         // Nothing to go on: no window to read and Teams is not capturing, so during
         // a meeting the mic is not live. The legacy inference, confined to this case.
         assert!(muted(None, None));
+    }
+
+    fn video_on(uia: Option<bool>, registry: bool) -> bool {
+        let mut s = AppState {
+            uia_video: uia,
+            last_registry_video: registry,
+            ..Default::default()
+        };
+        recompute_video(&mut s);
+        s.meeting.is_video_on
+    }
+
+    #[test]
+    fn uia_video_reading_wins_over_the_registry_flag() {
+        // The regression this guards against: a virtual-camera passthrough (e.g. NVIDIA
+        // Broadcast) can leave the registry's consent-store flag stuck, so a confident
+        // UIA reading must not be overridden by it either way.
+        assert!(video_on(Some(true), false));
+        assert!(!video_on(Some(false), true));
+    }
+
+    #[test]
+    fn falls_back_to_the_registry_flag_when_uia_has_no_reading() {
+        assert!(video_on(None, true));
+        assert!(!video_on(None, false));
     }
 }

--- a/tauri/src-tauri/src/uia_monitor.rs
+++ b/tauri/src-tauri/src/uia_monitor.rs
@@ -1,4 +1,4 @@
-//! Teams' in-app mute state, read via UI Automation.
+//! Teams' in-app mute and camera state, read via UI Automation.
 //!
 //! # Why UIA and not the audio stack
 //!
@@ -18,6 +18,15 @@
 //! The one place the state *is* visible is the meeting window's mute button, whose
 //! accessible name flips between `Mute mic` (live) and `Unmute mic` (muted).
 //!
+//! The camera signal has an analogous gap: `registry_monitor`'s Privacy Consent Store
+//! reading reflects physical-camera use, but a virtual-camera passthrough (e.g. NVIDIA
+//! Broadcast sitting between the real webcam and Teams) doesn't reliably route through
+//! the Frame Server capability check the consent store is fed by, so it can leave
+//! `LastUsedTimeStop` stuck non-zero even while video is genuinely on. The meeting
+//! window's camera button (`Turn Camera Off` while on, `Turn Camera On` while off) is
+//! read the same way as mute and, on Windows, takes precedence over the registry
+//! reading whenever a meeting window is present — see `recompute_video` in `lib.rs`.
+//!
 //! # Known limitations — please read before relying on this
 //!
 //! * **Needs a realised Teams window.** With Teams closed to the tray its processes have
@@ -36,10 +45,15 @@ use axuielement::prelude::*;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum UiaEvent {
     MuteChanged(bool),
-    /// macOS only: Teams' meeting-toolbar camera button flipped. Windows never constructs
-    /// this — its video signal comes from `registry_monitor` instead — so this variant does
-    /// not change Windows behavior at all.
+    /// Teams' meeting-toolbar camera button flipped. On Windows this takes precedence
+    /// over `registry_monitor`'s reading whenever available — see `recompute_video` in
+    /// `lib.rs` — because it reflects Teams' own belief about video state regardless of
+    /// which device is actually feeding the camera.
     VideoChanged(bool),
+    /// No Teams camera button visible (typically: not in a meeting, or no Teams window).
+    /// Distinct from `VideoChanged(false)` so `recompute_video` falls back to the
+    /// registry reading instead of assuming video is off.
+    VideoUnknown,
     /// No Teams mute button visible (typically: not in a meeting, or no Teams window).
     Unknown,
 }
@@ -68,8 +82,9 @@ fn classify(name: &str) -> Option<bool> {
 /// Action-based naming, same convention as `classify`: the label describes what clicking the
 /// button would do, not the current state. Verified live against Teams-for-Mac in Accessibility
 /// Inspector during a real meeting; exact casing is normalized away by lowercasing first, same
-/// as `classify`.
-#[cfg(target_os = "macos")]
+/// as `classify`. Not independently verified against Teams-for-Windows — if that turns out to
+/// use different wording, `search` below just keeps reporting no camera reading, same as before
+/// this was wired up on Windows.
 fn classify_camera(name: &str) -> Option<bool> {
     let lower = name.to_lowercase();
     if lower.contains("turn camera off") {
@@ -91,22 +106,25 @@ fn poll_blocking(tx: mpsc::Sender<UiaEvent>) {
         let ctx = match Uia::new() {
             Some(c) => c,
             None => {
-                log::error!("UiaMonitor: could not initialise UI Automation; Teams mute will not be detected");
+                log::error!("UiaMonitor: could not initialise UI Automation; Teams mute/camera will not be detected");
                 return;
             }
         };
 
-        let mut last: Option<bool> = None;
-        // Holding the element between polls avoids re-walking the whole WebView2 tree
-        // every second; it is only re-searched when the cached element goes stale.
-        let mut cached = None;
+        let mut last_mute: Option<bool> = None;
+        let mut last_video: Option<bool> = None;
+        // Holding the buttons found last time avoids re-walking the whole WebView2 tree
+        // every poll; each is only re-searched once its own cached element goes stale.
+        let mut cached_mute = None;
+        let mut cached_video = None;
 
         loop {
             std::thread::sleep(Duration::from_millis(750));
 
-            let reading = ctx.read_mute(&mut cached);
-            if reading != last {
-                match reading {
+            let (mute, video) = ctx.read(&mut cached_mute, &mut cached_video);
+
+            if mute != last_mute {
+                match mute {
                     Some(m) => {
                         log::info!("UiaMonitor: Teams mute → {m}");
                         let _ = tx.blocking_send(UiaEvent::MuteChanged(m));
@@ -116,7 +134,21 @@ fn poll_blocking(tx: mpsc::Sender<UiaEvent>) {
                         let _ = tx.blocking_send(UiaEvent::Unknown);
                     }
                 }
-                last = reading;
+                last_mute = mute;
+            }
+
+            if video != last_video {
+                match video {
+                    Some(v) => {
+                        log::info!("UiaMonitor: Teams camera → {v}");
+                        let _ = tx.blocking_send(UiaEvent::VideoChanged(v));
+                    }
+                    None => {
+                        log::info!("UiaMonitor: no Teams camera button visible");
+                        let _ = tx.blocking_send(UiaEvent::VideoUnknown);
+                    }
+                }
+                last_video = video;
             }
         }
     }
@@ -161,36 +193,61 @@ impl Uia {
         })
     }
 
-    /// Current mute state, or None when no Teams mute button can be found.
-    unsafe fn read_mute(
+    /// Current (mute, video) state; either is `None` when its button cannot be found.
+    unsafe fn read(
         &self,
-        cached: &mut Option<windows::Win32::UI::Accessibility::IUIAutomationElement>,
-    ) -> Option<bool> {
-        // Fast path: the button we found last time is usually still there, with only its
+        cached_mute: &mut Option<windows::Win32::UI::Accessibility::IUIAutomationElement>,
+        cached_video: &mut Option<windows::Win32::UI::Accessibility::IUIAutomationElement>,
+    ) -> (Option<bool>, Option<bool>) {
+        // Fast path: the buttons found last time are usually still there, with only their
         // accessible name changed.
-        if let Some(el) = cached.as_ref() {
-            if let Ok(name) = el.CurrentName() {
-                if let Some(muted) = classify(&name.to_string()) {
-                    return Some(muted);
-                }
-            }
-            // Stale (window closed, or the node was replaced) — fall through and re-search.
-            *cached = None;
+        let mut mute = cached_mute
+            .as_ref()
+            .and_then(|el| el.CurrentName().ok())
+            .and_then(|name| classify(&name.to_string()));
+        if mute.is_none() {
+            *cached_mute = None;
         }
 
-        self.search(cached)
+        let mut video = cached_video
+            .as_ref()
+            .and_then(|el| el.CurrentName().ok())
+            .and_then(|name| classify_camera(&name.to_string()));
+        if video.is_none() {
+            *cached_video = None;
+        }
+
+        if mute.is_some() && video.is_some() {
+            return (mute, video);
+        }
+
+        self.search(cached_mute, cached_video, &mut mute, &mut video);
+        (mute, video)
     }
 
+    /// Walks Teams' windows for whichever of the mute/camera buttons `read`'s fast path did
+    /// not already resolve, filling in `mute`/`video` in place and caching whatever is found
+    /// (leaving an already-resolved value and its cache entry untouched).
     unsafe fn search(
         &self,
-        cached: &mut Option<windows::Win32::UI::Accessibility::IUIAutomationElement>,
-    ) -> Option<bool> {
+        cached_mute: &mut Option<windows::Win32::UI::Accessibility::IUIAutomationElement>,
+        cached_video: &mut Option<windows::Win32::UI::Accessibility::IUIAutomationElement>,
+        mute: &mut Option<bool>,
+        video: &mut Option<bool>,
+    ) {
         use windows::Win32::UI::Accessibility::{TreeScope_Children, TreeScope_Descendants};
 
-        let top = self.root.FindAll(TreeScope_Children, &self.any).ok()?;
+        let top = match self.root.FindAll(TreeScope_Children, &self.any) {
+            Ok(t) => t,
+            Err(_) => return,
+        };
         let n = top.Length().unwrap_or(0);
 
         for i in 0..n {
+            if mute.is_some() && video.is_some() {
+                return;
+            }
+
             let win = match top.GetElement(i) {
                 Ok(w) => w,
                 Err(_) => continue,
@@ -202,7 +259,7 @@ impl Uia {
             }
 
             // Teams has several windows (main, meeting, notifications); only the meeting
-            // window carries a mute button, so check them all and take the first hit.
+            // window carries these buttons, so check them all and take the first hit.
             let found = match win.FindAll(TreeScope_Descendants, &self.buttons) {
                 Ok(b) => b,
                 Err(_) => continue,
@@ -210,6 +267,9 @@ impl Uia {
 
             let bn = found.Length().unwrap_or(0);
             for j in 0..bn {
+                if mute.is_some() && video.is_some() {
+                    break;
+                }
                 let btn = match found.GetElement(j) {
                     Ok(b) => b,
                     Err(_) => continue,
@@ -218,14 +278,24 @@ impl Uia {
                     Ok(s) => s.to_string(),
                     Err(_) => continue,
                 };
-                if let Some(muted) = classify(&name) {
-                    *cached = Some(btn);
-                    return Some(muted);
+
+                // A button matches at most one of these, so cloning here only to move
+                // `btn` outright below never wastes a real clone in practice — it is only
+                // needed to keep `btn` available for the second check.
+                if mute.is_none() {
+                    if let Some(m) = classify(&name) {
+                        *mute = Some(m);
+                        *cached_mute = Some(btn.clone());
+                    }
+                }
+                if video.is_none() {
+                    if let Some(v) = classify_camera(&name) {
+                        *video = Some(v);
+                        *cached_video = Some(btn);
+                    }
                 }
             }
         }
-
-        None
     }
 }
 
@@ -368,17 +438,17 @@ mod tests {
         assert_eq!(classify(""), None);
     }
 
-    #[cfg(target_os = "macos")]
     mod camera {
         use super::super::classify_camera;
 
         #[test]
         fn names_observed_from_teams_for_mac() {
             // User-verified live via Accessibility Inspector during a real Teams-for-Mac
-            // meeting. Exact casing beyond this paraphrase is NOT independently confirmed —
-            // classify_camera lowercases before matching, so casing differences shouldn't
-            // matter, but if this test starts failing against a real build, capture the
-            // verbatim string (as the Windows test above does) and update it here.
+            // meeting. Not yet independently verified against Teams-for-Windows — assumed
+            // to match since the mute strings above do too, but if Windows turns out to
+            // phrase it differently, capture the verbatim string and update this test; until
+            // then `search` just keeps reporting no camera reading there, same as before this
+            // was wired up on Windows.
             assert_eq!(classify_camera("Turn Camera Off"), Some(true));
             assert_eq!(classify_camera("Turn Camera On"), Some(false));
         }


### PR DESCRIPTION
## Summary
- Windows camera detection only checked one Privacy Consent Store registry key (`ConsentStore\webcam\MSTeams_8wekyb3d8bbwe`), which doesn't reliably update when a virtual-camera passthrough — e.g. NVIDIA Broadcast — sits between the physical webcam and Teams, since that path doesn't always route through the Frame Server capability check the store is fed by. Reported case: camera detection worked normally, but stopped working specifically when using the webcam through NVIDIA Broadcast.
- Windows now also reads Teams' own meeting-toolbar camera button via UI Automation, the same way mute is already detected (and the same way macOS already detects video). This reflects Teams' own belief about video state regardless of which device is actually feeding the camera.
- The UIA reading is authoritative whenever a meeting window is present; the registry reading is kept only as a fallback for before that window exists.

## Test plan
- [x] `cargo test` for the new `recompute_video` unit tests — not run by me; see note below
- [ ] Build on Windows and confirm a normal (non-virtual-camera) Teams call still reports camera on/off correctly
- [ ] Confirm camera detection now works with NVIDIA Broadcast enabled (the original report)
- [ ] Confirm the camera button's accessible name ("Turn Camera Off" / "Turn Camera On") matches on Teams-for-Windows — so far only verified live against Teams-for-Mac; if Windows phrases it differently, this degrades gracefully (falls back to the registry signal, same as before this change) rather than breaking

**Note:** this was written and reviewed on a machine with no Rust toolchain installed, so none of it has been compiler- or test-verified yet. Please run `cargo check`/`cargo test` and a real Windows build before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)