### PR TITLE
log_watcher: treat reportCallAccepted as a call going active

### DIFF
--- a/tauri/src-tauri/src/log_watcher.rs
+++ b/tauri/src-tauri/src/log_watcher.rs
@@ -23,6 +23,30 @@ pub enum LogEvent {
 /// declined call ended the running meeting (and e.g. restored smart-home
 /// speaker volume mid-meeting). Only ids that were seen active may close the
 /// call state, and only when the last one is gone.
+///
+/// # Why `reportCallAccepted` counts as active
+///
+/// Teams can lose a call inside its own VoIP coordinator and then never write
+/// the `NotifyCall*` pair for it at all. Observed 2026-08-25, when two calls
+/// rang at once: the accepted one logged
+///
+/// ```text
+/// reportCallAccepted for callId: a9ffc76c…
+/// <ERR> reportCallAccepted called, call does not exist, unexpected callId: a9ffc76c…
+/// ```
+///
+/// and, six minutes later, `reportCallEnded` with the same "call does not
+/// exist" error — no `reportIncomingCall`, no `NotifyCallActive`, no
+/// `NotifyCallEnded`. Since `NotifyCallActive`/`reportCallActive` was the only
+/// start marker, such a call registered as no meeting at all: `isinmeeting`
+/// stayed off for its whole duration.
+///
+/// `reportCallAccepted` closes that gap and is safe as a start marker for the
+/// reason the declined-call fix needs: across a full day of calls it appears
+/// for every *accepted* call and never for the declined one. Where Teams is
+/// behaving it arrives just before `NotifyCallActive`, which makes the start a
+/// second earlier and the second line a no-op. The end side needs no change:
+/// `reportCallEnded` already matches on the `CallEnded` substring.
 #[derive(Default)]
 struct CallState {
     /// Ids seen in a `NotifyCallActive`/`reportCallActive` line.
@@ -47,7 +71,10 @@ impl CallState {
     /// not a call line, or a call line that doesn't change the outcome).
     fn apply(&mut self, line: &str) -> Option<bool> {
         let was = self.in_call();
-        if line.contains("NotifyCallActive") || line.contains("reportCallActive") {
+        if line.contains("NotifyCallActive")
+            || line.contains("reportCallActive")
+            || line.contains("reportCallAccepted")
+        {
             match extract_call_id(line) {
                 Some(id) => {
                     log::info!("LogWatcher: call active ({id})");
@@ -372,6 +399,22 @@ mod tests {
         "HfpVoipCallCoordinatorImpl: NotifyCallEnded callId: d84becb7-4285-4d44-9d4d-e61364d07d11causeId: a879e043-6006-4daf-add5-d816bc102653";
     const MEETING_ENDED_TRACKER: &str =
         "TeamsCallTracker: CallEnded fired: d84becb7-4285-4d44-9d4d-e61364d07d11";
+    // Verbatim from 2026-08-25, the call Teams lost inside its own coordinator:
+    // accepted and ended, with no reportIncomingCall and no NotifyCall* pair.
+    const LOST_ACCEPTED: &str =
+        "HfpVoipCallCoordinatorImpl: reportCallAccepted for callId: a9ffc76c-1a94-427e-bdb3-ad8601f97232";
+    const LOST_ENDED: &str =
+        "HfpVoipCallCoordinatorImpl: reportCallEnded for callId: a9ffc76c-1a94-427e-bdb3-ad8601f97232causeId: c684a115-81ab-4a4a-903f-7f1e0b2c4d5a";
+    // The same log's declined call: it rang and timed out, and — the reason
+    // reportCallAccepted is safe to trust — it has no accepted-line at all.
+    const DECLINED_RING: &str =
+        "HfpVoipCallCoordinatorImpl: reportIncomingCall for callId: 88f6048b-26ea-4d66-82a0-445b24d1933f";
+    const DECLINED_ENDED: &str =
+        "HfpVoipCallCoordinatorImpl: NotifyCallEnded callId: 88f6048b-26ea-4d66-82a0-445b24d1933fcauseId: 50b47384-588f-4c10-8bec-0846e308868d";
+    // And an accepted line for a call Teams did *not* lose, so the pair
+    // reportCallAccepted → NotifyCallActive can be replayed in order.
+    const ACCEPTED_MEETING: &str =
+        "HfpVoipCallCoordinatorImpl: reportCallAccepted for callId: d84becb7-4285-4d44-9d4d-e61364d07d11";
 
     #[test]
     fn extracts_guid_glued_to_cause_id() {
@@ -467,6 +510,45 @@ mod tests {
         assert_eq!(calls.apply(ACTIVE_MEETING), Some(true));
         assert_eq!(calls.apply("SomeTelemetry: CallEndedReason summary"), None);
         assert!(calls.in_call());
+    }
+
+    // The 2026-08-25 incident: two calls rang at once, and the one that was
+    // accepted was lost inside Teams' own VoIP coordinator — it logged
+    // reportCallAccepted and, six minutes later, reportCallEnded, each followed
+    // by Teams' own "call does not exist" error, and never a NotifyCall* line.
+    // Before reportCallAccepted was trusted, that call was no meeting at all.
+    #[test]
+    fn a_call_teams_lost_still_starts_and_ends_the_meeting() {
+        let mut calls = CallState::default();
+        assert_eq!(calls.apply(LOST_ACCEPTED), Some(true));
+        assert!(calls.in_call());
+        assert_eq!(calls.apply(LOST_ENDED), Some(false));
+        assert!(!calls.in_call());
+    }
+
+    #[test]
+    fn an_accepted_line_before_the_active_line_is_not_a_second_call() {
+        // The healthy ordering: Teams writes reportCallAccepted just before
+        // NotifyCallActive for the same id. The second line must be a no-op,
+        // and one end-line must still close the meeting.
+        let mut calls = CallState::default();
+        assert_eq!(calls.apply(ACCEPTED_MEETING), Some(true));
+        assert_eq!(calls.apply(ACTIVE_MEETING), None);
+        assert_eq!(calls.apply(MEETING_ENDED), Some(false));
+    }
+
+    #[test]
+    fn a_declined_call_has_no_accepted_line_to_go_on() {
+        // Why trusting reportCallAccepted does not undo the declined-call fix:
+        // ringing and timing out produces no accepted-line, so a declined call
+        // still cannot start a meeting — nor end the one that is running.
+        let mut calls = CallState::default();
+        assert_eq!(calls.apply(DECLINED_RING), None);
+        assert!(!calls.in_call());
+
+        assert_eq!(calls.apply(ACTIVE_MEETING), Some(true));
+        assert_eq!(calls.apply(DECLINED_ENDED), None);
+        assert!(calls.in_call(), "the declined call must not end the meeting");
     }
 
     #[test]


### PR DESCRIPTION
## The problem

Teams can lose a call inside its own VoIP coordinator and then never write **any** `NotifyCall*` line for it. `NotifyCallActive`/`reportCallActive` is the only start marker `log_watcher` looks for, so such a call registers as no meeting at all — `isinmeeting` stays `off` for its whole duration and every downstream automation misses it.

Observed here on 2026-08-25 with two calls ringing at the same time; one accepted, one declined (times local):

```
10:31:28  reportIncomingCall  88f6048b            ← call B rings
10:31:36  reportCallAccepted  a9ffc76c            ← call A accepted
10:31:36  <ERR> reportCallAccepted called, call does not exist, unexpected callId: a9ffc76c
10:31:40  reportMuteStateChange a9ffc76c          ← same "call does not exist" error
10:31:42  presence → Busy
10:33:28  NotifyCallEnded 88f6048b                ← B rang out (declined)
10:37:42  reportCallEnded a9ffc76c                ← same error again
10:37:43  presence → Available
```

`a9ffc76c` — the call actually being held — has no `reportIncomingCall`, no `NotifyCallActive` and no `NotifyCallEnded`. It looks like Teams drops the second of two concurrent calls while the first one's incoming report is still in flight, and the call then only ever appears in lines its own tracker rejects.

## The fix

Trust `reportCallAccepted` as a call-active marker too. The end side needs no change: `apply` matches on the `CallEnded` substring, which `reportCallEnded` already contains.

## Why this does not undo the concurrent-call fix (#108)

Every call id from that day, tabulated:

| callId | reportIncoming | **reportCallAccepted** | **NotifyCallActive** | NotifyCallEnded | reportCallEnded |
|---|---|---|---|---|---|
| 2d36a172, 7245b7a7 (accepted) | ✓ | ✓ | ✓ | ✓ | ✓ |
| 88f6048b (**declined**) | ✓ | — | — | ✓ | — |
| a9ffc76c (**accepted, lost**) | — | ✓ | **—** | **—** | ✓ |
| 5 others | — | — | ✓ | ✓ | ✓ |

`reportCallAccepted` appears for every accepted call and never for the declined one, so a declined call still cannot start a meeting nor end a running one. Where Teams behaves, the accepted line arrives just before `NotifyCallActive` for the same id: the start lands about a second earlier and the later line is a no-op on the id set.

## Testing

Three new tests, lines verbatim from that log:

- `a_call_teams_lost_still_starts_and_ends_the_meeting` — the regression itself
- `an_accepted_line_before_the_active_line_is_not_a_second_call` — the healthy ordering stays idempotent
- `a_declined_call_has_no_accepted_line_to_go_on` — the #108 guarantee still holds

18 pass, clippy clean. Run in a scratch crate, since I cannot build the full crate here (WSL, Windows-only deps) — `tauri::async_runtime::spawn` swapped for `tokio::spawn`, nothing else changed.

## Notes

- Independent of my open #116 (rotation fix): that one touches `CallState`'s fields and `poll_loop`, this one touches the marker condition and adds tests. Either can merge first; if #116 lands first this needs no rebase.
- The `cargo clippy` tick will be red for a reason unrelated to this PR — `variant MeetingEnded is never constructed` in `uia_monitor.rs:66`, failing on master since 9f5d3eb. Details in [my comment on #116](https://github.com/jimmyeao/TEAMS2HA/pull/116#issuecomment-5390420494), including the one-line fix if you want it.

## Disclosure

Written with Claude Code, reviewed by me before opening. Same as my earlier PRs here (#93, #95–#99, #108, #116).

🤖 Generated with [Claude Code](https://claude.com/claude-code)