### PR TITLE
Fix clippy on Windows: MeetingEnded is matched but never constructed

### DIFF
--- a/tauri/src-tauri/examples/ax_probe.rs
+++ b/tauri/src-tauri/examples/ax_probe.rs
@@ -18,12 +18,20 @@
 //! (VoiceOver's) sped it up when tried against a real call; it just needs patience — the
 //! regular 750ms poll in `uia_monitor` picks it up on its own once Chromium finishes.
 
+//! Everything below is gated to macOS: `axuielement` and `libproc` are macOS-only
+//! dependencies, and `cargo clippy --all-targets` builds examples on every platform, so
+//! without the gate this file fails to resolve its imports on the Windows runner.
+
+#[cfg(target_os = "macos")]
 use axuielement::ax_attribute::attributes::{
     AX_DESCRIPTION_ATTRIBUTE, AX_ROLE_ATTRIBUTE, AX_TITLE_ATTRIBUTE, AX_WINDOWS_ATTRIBUTE,
 };
+#[cfg(target_os = "macos")]
 use axuielement::AXUIElement;
+#[cfg(target_os = "macos")]
 use std::time::Duration;
 
+#[cfg(target_os = "macos")]
 fn teams_pid() -> Option<u32> {
     use libproc::proc_pid::{pidpath, ProcType};
 
@@ -37,6 +45,7 @@ fn teams_pid() -> Option<u32> {
     })
 }
 
+#[cfg(target_os = "macos")]
 fn walk(el: &AXUIElement, depth: u32) {
     if depth > 40 {
         return;
@@ -71,6 +80,7 @@ fn walk(el: &AXUIElement, depth: u32) {
     }
 }
 
+#[cfg(target_os = "macos")]
 fn main() {
     let Some(pid) = teams_pid() else {
         println!("Microsoft Teams not found running.");
@@ -100,4 +110,9 @@ fn main() {
         }
         std::thread::sleep(Duration::from_secs(3));
     }
+}
+
+#[cfg(not(target_os = "macos"))]
+fn main() {
+    eprintln!("ax_probe is a macOS-only diagnostic; there is nothing to probe here.");
 }

--- a/tauri/src-tauri/src/uia_monitor.rs
+++ b/tauri/src-tauri/src/uia_monitor.rs
@@ -63,6 +63,13 @@ pub enum UiaEvent {
     /// in `poll_blocking` (not just "both `Unknown` this poll") because a backgrounded Teams
     /// window can make Chromium briefly skip AX-tree upkeep, which must not be mistaken for
     /// the call having ended.
+    ///
+    /// Only ever constructed by the macOS `poll_blocking`, while `handle_uia_event` matches
+    /// it on every platform to keep that match exhaustive — so on Windows this is a variant
+    /// that is matched but never built, which `-D warnings` rejects as dead code. Silenced
+    /// rather than `cfg`-gated: gating the variant would mean gating its match arm too, and
+    /// the arm is what documents the macOS behaviour.
+    #[cfg_attr(not(target_os = "macos"), allow(dead_code))]
     MeetingEnded,
 }
 


### PR DESCRIPTION
## The problem

`cargo clippy --all-targets -- -D warnings` has failed on master since 9f5d3eb (16 Aug), with a single error:

```
error: variant `MeetingEnded` is never constructed
  --> src\uia_monitor.rs:66:5
error: could not compile `teams2ha` (lib) due to 1 previous error
```

`UiaEvent::MeetingEnded` is constructed only inside the macOS `poll_blocking`, while `handle_uia_event` matches it on every platform so that match stays exhaustive. On the Windows runner that leaves a variant which is matched but never built. `UiaEvent` lives in a private module and is never exposed through a public signature, so it genuinely is unreachable there — the lint is right, it just has nothing useful to say about a deliberately platform-specific variant.

Because clippy is the de-facto compile check here, this also means no PR against master can go green, and the Rust side of every contribution currently goes unverified by CI. It is what is holding the red tick on my #116 and #119.

## The fix

```rust
#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
MeetingEnded,
```

Silenced rather than `cfg`-gated: gating the variant would mean gating its match arm too, and that arm is where the macOS behaviour is documented. A short comment on the variant explains why the attribute is there.

## Verification

I cannot build the full crate here (WSL, Windows-only deps), so I reproduced the exact shape in a scratch crate — private module, variant constructed only under `cfg(target_os = "macos")`, matched by a private handler:

- without the attribute: `error: variant MeetingEnded is never constructed` — the same error, on a non-macOS host
- with the attribute: clean

Your CI on this PR is the real check, and if it goes green that is the whole point of the change.

## Disclosure

Written with Claude Code, reviewed by me before opening. Same as my earlier PRs here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)